### PR TITLE
Fixed small errors (typos, markup etc.)

### DIFF
--- a/ok01.html
+++ b/ok01.html
@@ -169,7 +169,7 @@ Makefile</pre>
 							7.</li>
 						<li>The remainder is the last digit of the answer in hexadecimal, in the example this
 							is 7.</li>
-						<li>Repeat steps 2 and 3 again with the result of the last division until the reuslt
+						<li>Repeat steps 2 and 3 again with the result of the last division until the result
 							is 0. For example 35 &divide; 16 = 2 remainder 3, so 3 is the next digit of the
 							answer. 2 &divide; 16 = 0 remainder 2, so 2 is the next digit of the answer.</li>
 						<li>Once the result of the division is 0, you can stop. The answer is just the remainders

--- a/ok02.html
+++ b/ok02.html
@@ -112,7 +112,7 @@
 						zero and negative. When a cmp instruction is issued, it subtracts the second argument
 						from the first, and notes down whether it is positive, zero or negative with these
 						fields. Zero means the numbers were equal (a-b=0 implies a=b), positive means a
-						is bigger than b (a-b)&gt;0 implies a&gt;b) and negative less than. A variety of
+						is bigger than b (a-b&gt;0 implies a&gt;b) and negative less than. A variety of
 						other comparison instructions exist, but cmp is the most intuitive. </li>
 				</ol>
 				<p>Spot a mistake? You can help improve this tutorial on <a href="https://github.com/chadderz121/bakingpi-www">GitHub</a>.</p>

--- a/ok02.html
+++ b/ok02.html
@@ -35,16 +35,16 @@
 					sub r2,#1<br />
 					cmp r2,#0<br />
 					bne wait1$<br />
-				</div>
+				</p></div>
 				<div class="commandBox"><p>
 					<span class="armCodeInline">sub reg,#val</span> subtracts the number <span class="armCodeInline">
-						val</span> from the value in <span class="armCodeInline">reg</span>.</div>
+						val</span> from the value in <span class="armCodeInline">reg</span>.</p></div>
 				<div class="commandBox"><p>
 					<span class="armCodeInline">cmp reg,#val</span> compares the value in <span class="armCodeInline">
-						reg</span> with the number <span class="armCodeInline">val</span>.</div>
+						reg</span> with the number <span class="armCodeInline">val</span>.</p></div>
 				<div class="commandBox"><p>
 					Suffix <span class="armCodeInline">ne</span> causes the command to be executed only
-					if the last comparison determined that the numbers were not equal.</div>
+					if the last comparison determined that the numbers were not equal.</p></div>
 				<p>
 					The code above is a generic piece of code that creates a delay, which thanks to
 					every Raspberry Pi being basically the same, is roughly the same time. How it does


### PR DESCRIPTION
Just a small typo fix.

Edit: I've included some other small fixes for lesson OK02 including fixes for HTML markup errors shown by VIM plugin "syntastic" respectively the underlying HTML Tidy).
