### PR TITLE
Info box for MLA instruction in lesson Screen02

### DIFF
--- a/screen01.html
+++ b/screen01.html
@@ -719,7 +719,7 @@
 					<li>
 						<div class="armCodeBlock"><p>
 							mov r0,fbInfoAddr<br />
-							add r0,#0x40000000
+							add r0,#0x40000000<br />
 							mov r1,#1<br />
 							bl MailboxWrite<br />
 						</div>

--- a/screen02.html
+++ b/screen02.html
@@ -137,6 +137,12 @@
 							add addr, px,lsl #1<br />
 							.unreq px<br />
 						</div>
+						<div class="commandBox"><p>
+							<span class="armCodeInline">mla dst,reg1, reg2,reg3</span> multiplies the values
+							from <span class="armCodeInline">reg1</span> and <span class="armCodeInline">reg2</span>,
+							adds the value from <span class="armCodeInline">reg3</span> and places
+							the least significant 32 bits of the result in
+							<span class="armCodeInline">dst</span>.</p></div>
 						<p>
 							Admittedly, this code is specific to high colour frame buffers, as I use a bit shift
 							directly to compute this address. You may wish to code a version of this function


### PR DESCRIPTION
Added an info box explaining the MLA instruction. The explanation is taken from http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0489g/Cihihggj.html and adapted to match the other explanations by using similar placeholder names.
